### PR TITLE
xgb gpu support

### DIFF
--- a/python/tvm/auto_scheduler/cost_model/xgb_model.py
+++ b/python/tvm/auto_scheduler/cost_model/xgb_model.py
@@ -108,6 +108,7 @@ class XGBModelInternal:
         self,
         use_workload_embedding=True,
         use_data_argumentation=False,
+        use_gpu=False,
         few_shot_learning="base_only",
         verbose_eval=25,
         seed=None):
@@ -146,6 +147,10 @@ class XGBModelInternal:
             "seed": seed or 43,
             "disable_default_eval_metric": 1,
         }
+
+        # gpu support
+        if use_gpu:
+            self.xgb_params['tree_method'] = 'gpu_hist'
 
         # models
         self.base_model = None


### PR DESCRIPTION
This pr do a quick support of xgb gpu. I have done one quick comparison of time between CPU and GPU for the full dataset (about 9.7G).

CPU: Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz, 64 Cores
GPU: A100

CPU | 55m13.445s
-- | --
GPU | 18m50.515s

So GPU support could save our time when to train xgb cost model

The usage: `python train_model.py --use-gpu true`.

More detail output:

CPU：
Model: xgb
RMSE: 0.0933
R^2: 0.7521
pairwise comparision accuracy: 0.8514
average peak score@1: 0.8756
average peak score@5: 0.9345

GPU:
Model: xgb
RMSE: 0.0932
R^2: 0.7395
pairwise comparision accuracy: 0.8518
average peak score@1: 0.8765
average peak score@5: 0.9349
